### PR TITLE
Task/devsite 2040/support multiple vm sizes

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\src\DeployToAzure.Tests\packages.config" />
-  <repository path="..\src\DeployToAzure\packages.config" />
-</repositories>

--- a/src/DeployToAzure.Tests/ConfigurationParserTests.cs
+++ b/src/DeployToAzure.Tests/ConfigurationParserTests.cs
@@ -43,6 +43,7 @@ namespace DeployToAzure.Tests.ConfigurationParserTests
                 writer.WriteLine("    <MaxRetries>12</MaxRetries>");
                 writer.WriteLine("    <RetryIntervalInSeconds>12</RetryIntervalInSeconds>");
                 writer.WriteLine("    <Force>true</Force>");
+                writer.WriteLine("    <ChangeVMSize>small</ChangeVMSize>");
                 writer.WriteLine("  </Params>");
             }
 
@@ -125,6 +126,12 @@ namespace DeployToAzure.Tests.ConfigurationParserTests
         public void it_parses_the_force_setting()
         {
             Assert.That(configuration.Force);
+        }
+
+        [Test]
+        public void it_parsers_the_vm_size()
+        {
+            Assert.That(configuration.ChangeVMSize, Is.EqualTo("small"));
         }
     }
 }

--- a/src/DeployToAzure.Tests/ConfigurationParserTests.cs
+++ b/src/DeployToAzure.Tests/ConfigurationParserTests.cs
@@ -36,7 +36,7 @@ namespace DeployToAzure.Tests.ConfigurationParserTests
                 writer.WriteLine("    <CertFileName>cert file name</CertFileName>");
                 writer.WriteLine("    <CertPassword>cert password</CertPassword>");
                 writer.WriteLine("    <PackageFileName>package file name</PackageFileName>");
-                writer.WriteLine("    <ServiceConfigurationPath>{0}</ServiceConfigurationPath>",serviceConfigurationPath);
+                writer.WriteLine("    <ServiceConfigurationPath>{0}</ServiceConfigurationPath>", serviceConfigurationPath);
                 writer.WriteLine("    <DeploymentLabel>deployment label</DeploymentLabel>");
                 writer.WriteLine("    <DeploymentName>deployment name</DeploymentName>");
                 writer.WriteLine("    <RoleName>role name</RoleName>");
@@ -44,6 +44,8 @@ namespace DeployToAzure.Tests.ConfigurationParserTests
                 writer.WriteLine("    <RetryIntervalInSeconds>12</RetryIntervalInSeconds>");
                 writer.WriteLine("    <Force>true</Force>");
                 writer.WriteLine("    <ChangeVMSize>small</ChangeVMSize>");
+                writer.WriteLine("    <ChangeWebRoleVMSize>x-small</ChangeWebRoleVMSize>");
+                writer.WriteLine("    <ChangeWorkerRoleVMSize>Large</ChangeWorkerRoleVMSize>");
                 writer.WriteLine("  </Params>");
             }
 
@@ -129,9 +131,21 @@ namespace DeployToAzure.Tests.ConfigurationParserTests
         }
 
         [Test]
-        public void it_parsers_the_vm_size()
+        public void it_parses_the_vm_size()
         {
             Assert.That(configuration.ChangeVMSize, Is.EqualTo("small"));
+        }
+
+        [Test]
+        public void it_parses_the_web_role_vm_size()
+        {
+            Assert.That(configuration.ChangeWebRoleVMSize, Is.EqualTo("x-small"));
+        }
+
+        [Test]
+        public void it_parses_the_worker_role_vm_size()
+        {
+            Assert.That(configuration.ChangeWorkerRoleVMSize, Is.EqualTo("Large"));
         }
     }
 }

--- a/src/DeployToAzure.Tests/Management/AzureDeploymentLowLevelApi_BeginCreateDeployment_Tests.cs
+++ b/src/DeployToAzure.Tests/Management/AzureDeploymentLowLevelApi_BeginCreateDeployment_Tests.cs
@@ -41,9 +41,7 @@ namespace DeployToAzure.Tests.Management
 
             var api = new AzureManagementLowLevelApi(http);
             var config = MockRepository.GenerateStub<IDeploymentConfiguration>();
-            Assert.That(
-                () => api.BeginCreate(TestDeploymentUri, config), 
-                Throws.TypeOf<UnhandledHttpException>());
+            Assert.That(() => api.BeginCreate(TestDeploymentUri, config), Throws.TypeOf<UnhandledHttpException>());
         }
 
         [Test]

--- a/src/DeployToAzure/ConfigurationParser.cs
+++ b/src/DeployToAzure/ConfigurationParser.cs
@@ -30,23 +30,23 @@ namespace DeployToAzure
             string changeVMSize = arguments.ChangeVMSize.Value;
 
             OurTrace.TraceInfo("Using parameters:");
-            OurTrace.TraceInfo(string.Format("subscriptionId: {0}", subscriptionId));
-            OurTrace.TraceInfo(string.Format("serviceName: {0}", serviceName));
-            OurTrace.TraceInfo(string.Format("deploymentSlot: {0}", deploymentSlot));
-            OurTrace.TraceInfo(string.Format("storageAccountName: {0}", storageAccountName));
-            OurTrace.TraceInfo(string.Format("storageAccountKey: {0}", storageAccountKey));
-            OurTrace.TraceInfo(string.Format("certFileName: {0}", certFileName));
-            OurTrace.TraceInfo(string.Format("certPassword: {0}", certPassword));
-            OurTrace.TraceInfo(string.Format("packageFileName: {0}", packageFileName));
-            OurTrace.TraceInfo(string.Format("serviceConfigurationPath: {0}", serviceConfigurationPath));
-            OurTrace.TraceInfo(string.Format("deploymentLabel: {0}", deploymentLabel));
-            OurTrace.TraceInfo(string.Format("deploymentName: {0}", deploymentName));
-            OurTrace.TraceInfo(string.Format("roleName: {0}", roleName));
-            OurTrace.TraceInfo(string.Format("force: {0}", force));
-            OurTrace.TraceInfo(string.Format("maxRetries: {0}", maxRetries));
-            OurTrace.TraceInfo(string.Format("retryIntervalInSeconds: {0}", retryIntervalInSeconds));
-            OurTrace.TraceInfo(string.Format("blobPathToDeploy: {0}", blobPathToDeploy));
-            OurTrace.TraceInfo(string.Format("changeVMSize: {0}", changeVMSize));
+            OurTrace.TraceInfo($"subscriptionId: {subscriptionId}");
+            OurTrace.TraceInfo($"serviceName: {serviceName}");
+            OurTrace.TraceInfo($"deploymentSlot: {deploymentSlot}");
+            OurTrace.TraceInfo($"storageAccountName: {storageAccountName}");
+            OurTrace.TraceInfo($"storageAccountKey: {storageAccountKey}");
+            OurTrace.TraceInfo($"certFileName: {certFileName}");
+            OurTrace.TraceInfo($"certPassword: {certPassword}");
+            OurTrace.TraceInfo($"packageFileName: {packageFileName}");
+            OurTrace.TraceInfo($"serviceConfigurationPath: {serviceConfigurationPath}");
+            OurTrace.TraceInfo($"deploymentLabel: {deploymentLabel}");
+            OurTrace.TraceInfo($"deploymentName: {deploymentName}");
+            OurTrace.TraceInfo($"roleName: {roleName}");
+            OurTrace.TraceInfo($"force: {force}");
+            OurTrace.TraceInfo($"maxRetries: {maxRetries}");
+            OurTrace.TraceInfo($"retryIntervalInSeconds: {retryIntervalInSeconds}");
+            OurTrace.TraceInfo($"blobPathToDeploy: {blobPathToDeploy}");
+            OurTrace.TraceInfo($"changeVMSize: {changeVMSize}");
 
             var serviceConfigurationString = File.ReadAllText(serviceConfigurationPath);
 

--- a/src/DeployToAzure/ConfigurationParser.cs
+++ b/src/DeployToAzure/ConfigurationParser.cs
@@ -28,6 +28,8 @@ namespace DeployToAzure
             string retryIntervalInSeconds = arguments.RetryIntervalInSeconds.Value ?? "15";
             string blobPathToDeploy = arguments.BlobPathToDeploy.Value;
             string changeVMSize = arguments.ChangeVMSize.Value;
+            string changeWebRoleVMSize = arguments.ChangeWebRoleVMSize.Value;
+            string changeWorkerRoleVMSize = arguments.ChangeWorkerRoleVMSize.Value;
 
             OurTrace.TraceInfo("Using parameters:");
             OurTrace.TraceInfo($"subscriptionId: {subscriptionId}");
@@ -47,6 +49,8 @@ namespace DeployToAzure
             OurTrace.TraceInfo($"retryIntervalInSeconds: {retryIntervalInSeconds}");
             OurTrace.TraceInfo($"blobPathToDeploy: {blobPathToDeploy}");
             OurTrace.TraceInfo($"changeVMSize: {changeVMSize}");
+            OurTrace.TraceInfo($"changeWebRoleVMSize: {changeWebRoleVMSize}");
+            OurTrace.TraceInfo($"changeWorkerRoleVMSize: {changeWorkerRoleVMSize}");
 
             var serviceConfigurationString = File.ReadAllText(serviceConfigurationPath);
 
@@ -67,6 +71,8 @@ namespace DeployToAzure
                 RetryIntervalInSeconds = int.Parse(retryIntervalInSeconds),
                 BlobPathToDeploy = blobPathToDeploy,
                 ChangeVMSize = changeVMSize,
+                ChangeWebRoleVMSize = changeWebRoleVMSize,
+                ChangeWorkerRoleVMSize = changeWorkerRoleVMSize,
             };
         }
     }

--- a/src/DeployToAzure/DeployToAzure.ps1
+++ b/src/DeployToAzure/DeployToAzure.ps1
@@ -17,7 +17,9 @@ function Create-DeployParams
     [string] $CertPassword = $(throw "Parameter -CertPassword [string] is required."),
     [IO.FileInfo] $OutFile = $(throw "Parameter -OutFile [IO.FileInfo] is required."),
     [IO.FileInfo] $BlobPathToDeploy = $null,
-    [string] $ChangeVMSize = $null
+    [string] $ChangeVMSize = $null,
+    [string] $ChangeWebRoleVMSize = $null,
+    [string] $ChangeWorkerRoleVMSize = $null
   )
   
   $params = @{
@@ -51,6 +53,11 @@ function Create-DeployParams
     $params.ChangeVMSize = $ChangeVMSize
   }
   
+  if(($ChangeWebRoleVMSize -ne $null) -and ($ChangeWorkerRoleVMSize -ne $null)) {
+    $params.ChangeWebRoleVMSize = $ChangeWebRoleVMSize
+    $params.ChangeWorkerRoleVMSize = $ChangeWorkerRoleVMSize
+}
+
   $xml = "<Params>"
   $params.Keys | %{ $xml += "`n  <$($_)>$($params[$_])</$($_)>" }
   $xml += "`n</Params>"

--- a/src/DeployToAzure/Management/DeploymentConfiguration.cs
+++ b/src/DeployToAzure/Management/DeploymentConfiguration.cs
@@ -38,6 +38,8 @@ namespace DeployToAzure.Management
         public int RetryIntervalInSeconds;
         public string BlobPathToDeploy;
         public string ChangeVMSize;
+        public string ChangeWebRoleVMSize;
+        public string ChangeWorkerRoleVMSize;
 
         public string MakeCreateDeploymentMessage()
         {

--- a/src/DeployToAzure/PackageManifest.cs
+++ b/src/DeployToAzure/PackageManifest.cs
@@ -15,6 +15,7 @@ namespace DeployToAzure
 
         public void SetHash(Uri targetUri, byte[] sha2Hash)
         {
+            ManifestStream.Stream.Position = 0;
             var hashText = string.Join("", sha2Hash.Select(x => x.ToString("X2")));
             var manifestXml = XDocument.Load(ManifestStream.Stream);
             var uriString = targetUri.OriginalString;

--- a/src/DeployToAzure/Program.cs
+++ b/src/DeployToAzure/Program.cs
@@ -145,14 +145,14 @@ namespace DeployToAzure
 
                     if (string.IsNullOrWhiteSpace(configuration.StorageAccountKey))
                     {
-                        OurTrace.TraceInfo(string.Format("Looking up storage keys for account: {0}", configuration.StorageAccountName));
+                        OurTrace.TraceInfo($"Looking up storage keys for account: {configuration.StorageAccountName}");
                         var storageKeys = azureDeploymentDeploymentLowLevelApi.GetStorageAccountKeys(subscriptionId, configuration.StorageAccountName);
 
                         configuration.StorageAccountKey = storageKeys.FirstOrDefault();
 
                         if (string.IsNullOrWhiteSpace(configuration.StorageAccountKey))
                         {
-                            OurTrace.TraceError(string.Format("Couldn't find any keys for storage account: {0}", configuration.StorageAccountName));
+                            OurTrace.TraceError($"Couldn't find any keys for storage account: {configuration.StorageAccountName}");
                             throw new InvalidOperationException("No suitable storage account keys.");
                         }
                     }
@@ -178,7 +178,8 @@ namespace DeployToAzure
                     }
                     catch(BadRequestException ex)
                     {
-                        OurTrace.TraceError(string.Format("Upgrade failed with message: {0}\r\n, **** {1}", ex, fallbackToReplaceDeployment ? "falling back to replace." : "exiting."));
+                        OurTrace.TraceError(
+                            $"Upgrade failed with message: {ex}\r\n, **** {(fallbackToReplaceDeployment ? "falling back to replace." : "exiting.")}");
                         // retry using CreateOrReplaceDeployment, since we might have tried to do something that isn't allowed with UpgradeDeployment.
                         if (fallbackToReplaceDeployment)
                             deploymentSlotManager.CreateOrReplaceDeployment(configuration);
@@ -195,7 +196,7 @@ namespace DeployToAzure
             }
             catch(Exception ex)
             {
-                OurTrace.TraceError(string.Format("exception!\n{0}", ex));
+                OurTrace.TraceError($"exception!\n{ex}");
                 return -1;
             }
             return 0;
@@ -205,8 +206,8 @@ namespace DeployToAzure
         {
             if (!ValidateVmSize(newVmSize))
             {
-                OurTrace.TraceError(string.Format("Invalid vmsize: {0} - should be ({1})", newVmSize,
-                    string.Join(" | ", ValidVmSizeValues)));
+                OurTrace.TraceError(
+                    $"Invalid vmsize: {newVmSize} - should be ({string.Join(" | ", ValidVmSizeValues)})");
                 Environment.Exit(-2);
             }
 
@@ -246,7 +247,7 @@ namespace DeployToAzure
 
         private static void DeleteBlob(string packageUrl, string storageAccountName, string storageAccountKey)
         {
-            OurTrace.TraceInfo(string.Format("Deleting blob {0}", packageUrl));
+            OurTrace.TraceInfo($"Deleting blob {packageUrl}");
 
             var packageUri = new Uri(packageUrl);
             var credentials = new StorageCredentials(storageAccountName, storageAccountKey);
@@ -257,7 +258,7 @@ namespace DeployToAzure
 
         private static void UploadBlob(string packageFileName, string packageUrl, string storageAccountName, string storageAccountKey)
         {
-            OurTrace.TraceInfo(string.Format("Uploading blob from {0} to {1}", packageFileName, packageUrl));
+            OurTrace.TraceInfo($"Uploading blob from {packageFileName} to {packageUrl}");
 
             var packageUri = new Uri(packageUrl);
             var credentials = new StorageCredentials(storageAccountName, storageAccountKey);
@@ -272,7 +273,7 @@ namespace DeployToAzure
 
         private static void DeployBlobs(string blobPathToDeploy, string storageAccountName, string storageAccountKey)
         {
-            OurTrace.TraceInfo(string.Format("Deploying blobs from {0} to {1}", blobPathToDeploy, storageAccountName));
+            OurTrace.TraceInfo($"Deploying blobs from {blobPathToDeploy} to {storageAccountName}");
 
             var credentials = new StorageCredentials(storageAccountName, storageAccountKey);
             var storageAccount = new CloudStorageAccount(credentials, true);
@@ -286,7 +287,7 @@ namespace DeployToAzure
                 folder =>
                 {
                     client.GetContainerReference(folder).CreateIfNotExists();
-                    OurTrace.TraceInfo(string.Format("Created container: {0}", folder));
+                    OurTrace.TraceInfo($"Created container: {folder}");
                 });
 
             var files = from folder in folders
@@ -303,7 +304,7 @@ namespace DeployToAzure
                     var blob = container.GetBlockBlobReference(f.Item2);
 
                     blob.UploadFromFile(f.Item3);
-                    OurTrace.TraceInfo(string.Format("Uploaded Blob: {0} => {1}:{2}", f.Item3, f.Item1, f.Item2));
+                    OurTrace.TraceInfo($"Uploaded Blob: {f.Item3} => {f.Item1}:{f.Item2}");
                 });
         }
     }

--- a/src/DeployToAzure/ServiceDefinition.cs
+++ b/src/DeployToAzure/ServiceDefinition.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.IO;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace DeployToAzure
@@ -21,11 +21,13 @@ namespace DeployToAzure
             PartStream.Dispose();
         }
 
-        public void ChangeVMSizes(string newVMSize)
+        public void ChangeVmSize(string roleName, string newVmSize)
         {
+            PartStream.Stream.Position = 0;
             var rootElement = XDocument.Load(PartStream.Stream);
-            foreach (var element in rootElement.Elements().Elements())
-                element.SetAttributeValue("vmsize", newVMSize);
+            var element = rootElement.Elements().Elements().First(x => string.Equals(x.Name.LocalName, roleName, StringComparison.OrdinalIgnoreCase));
+
+            element.SetAttributeValue("vmsize", newVmSize);
 
             PartStream.Stream.Position = 0;
             rootElement.Save(PartStream.Stream);
@@ -33,5 +35,5 @@ namespace DeployToAzure
 
             Manifest.SetHash(PartStream.Rel.TargetUri, PartStream.ComputeHash());
         }
-    }
+   }
 }


### PR DESCRIPTION
This adds support for specifying differing sizes for the WebRole and WorkerRole VMs ... At the moment it only support IFP and MMD's use of a single role of each type.

When specified together ChangeWebRoleVMSize and ChangeWorkerRoleVMSize on the CLI tool take precedence over the older ChangeVMSize value (which is ignored in these cases).

** This does require updates to the deployment scripts of products that use it .... 

